### PR TITLE
Fix closing search bar on button click

### DIFF
--- a/gitforme/src/PageContent/AppHeader.jsx
+++ b/gitforme/src/PageContent/AppHeader.jsx
@@ -58,7 +58,7 @@ export const AppHeader = ({ isAuthenticated, user, onLogout, onLogin, repoUrl, s
                                             className="w-full px-4 py-2 border-2 border-black rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500 placeholder-gray-500"
                                             aria-label="Repository URL"
                                         />
-                                        <button onClick={oncook} className="bg-[#F9C79A] text-black font-bold px-6 py-2 border-2 border-black rounded-lg hover:bg-amber-400 transition-colors shadow-[3px_3px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5 whitespace-nowrap">
+                                        <button onClick={()=>{oncook(), setSearchOpen(false)}} className="bg-[#F9C79A] text-black font-bold px-6 py-2 border-2 border-black rounded-lg hover:bg-amber-400 transition-colors shadow-[3px_3px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5 whitespace-nowrap">
                                             cook
                                         </button>
                                     </div>
@@ -99,7 +99,7 @@ export const AppHeader = ({ isAuthenticated, user, onLogout, onLogin, repoUrl, s
 
                                         {isAuthenticated ? (
                                             <>
-                                                <span className="font-semibold hidden lg:inline">Hi, {user?.username}!</span>
+                                                <span className="font-semibold lg:hidden inline">Hi, {user?.username}!</span>
                                                 <button onClick={onLogout} className="flex items-center gap-2 px-3 py-1.5 bg-white border-2 border-black rounded-lg hover:bg-gray-100 transition-colors font-semibold shadow-[3px_3px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5">
                                                     <LogoutIcon />
                                                     <span className="md:inline">Logout</span>


### PR DESCRIPTION
# [Type]: Bug

## 📄 Description

When clicking on the cook button, the search bar remained at the same position on the mobile view, so this pull request fixes this.

**Changes made:**
- Changed isSearchOpen from true to false