### PR TITLE
fix the clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Want to run GitForMe on your own machine? Here’s how.
 
 1.  **Clone the Repository**
     ```sh
-    git clone [https://github.com/herin7/gitforme.git](https://github.com/herin7/gitforme.git)
+    git clone https://github.com/herin7/gitforme.git
     cd gitforme
     ```
 


### PR DESCRIPTION
## 📄 Description
Earlier copying the git clone command form the README gives error because the URL was redundant ans was not in the correct form. I corrected that.

**Changes made:**
I just remove the redundant URL and `()` `[]`

## ✅ Checklist
- [x] My code follows the project's coding guidelines
- [x] I have tested these changes locally
- [x] I have added/updated necessary documentation (comments, README, etc.)
- [x] I have linked the related issue(s)
- [x] I've reviewed my own code

## 🔗 Related Issues
Fixes #31 

## 📸 Visual Changes (if applicable)

**Before:**
<img width="926" height="161" alt="image" src="https://github.com/user-attachments/assets/cd8d4f29-e473-4234-b871-4a20e7be0aa0" />


**After:**
<img width="926" height="161" alt="image" src="https://github.com/user-attachments/assets/272bb203-c51a-44ee-9873-4b046c743953" />


## 🙏 Additional Notes
Thanks, Hope this is useful, although this is a small fix (contributing for the first time). Feel free to discuss anything related.