### PR TITLE
feat: Add Swagger auto-generation and serve API documentation at /api-docs

### DIFF
--- a/server/Routes/AuthRoute.js
+++ b/server/Routes/AuthRoute.js
@@ -1,16 +1,70 @@
 const router = require('express').Router();
 const { githubCallback, verifyUser } = require('../Controllers/AuthController');
 
-// Redirect to GitHub for OAuth
+/**
+ * @swagger
+ * /api/auth/github:
+ *   get:
+ *     description: Redirects the user to GitHub for OAuth authentication.
+ *     responses:
+ *       302:
+ *         description: Redirect to GitHub OAuth
+ */
 router.get('/github', (req, res) => {
     const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&scope=user:email`;
     res.redirect(githubAuthUrl);
 });
 
-// Handle the callback from GitHub
+/**
+ * @swagger
+ * /api/auth/github/callback:
+ *   get:
+ *     description: Handles the callback from GitHub after OAuth authentication.
+ *     responses:
+ *       302:
+ *         description: Redirect to Home after Login
+ *       400:
+ *         description: Error: No authorization code received.
+ *       500:
+ *         description: Error: Could not retrieve access token.
+ */
 router.get('/github/callback', githubCallback);
 
-// Verify user token for frontend
+/**
+ * @swagger
+ * /api/auth/verifyUser:
+ *   post:
+ *     description: Verifies the user token for the frontend.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: User verified
+ */
 router.post('/verifyUser', verifyUser);
+
+/**
+ * @swagger
+ * /api/auth/logout:
+ *   post:
+ *     description: Clears the user token & Logs out the user.
+ *     responses:
+ *       200:
+ *         description: Logged out Successfully.
+ *       500:
+ *         description: Logout failed.
+ */
+router.post('/logout', (req, res) => {
+    req.session.destroy((err) => {
+        if (err) return res.status(500).json({ message: 'Logout failed' });
+        res.clearCookie('token');
+        res.json({ status: true });
+    });
+});
+
 
 module.exports = router;

--- a/server/Routes/InsightRoutes.js
+++ b/server/Routes/InsightRoutes.js
@@ -1,6 +1,17 @@
 const router = require('express').Router();
 const { fetchDependencyHealth } = require('../Controllers/InsightController');
 
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/insights/dependencies:
+ *   get:
+ *     description: Returns dependency health insights for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Dependency health insights retrieved
+ *       500:
+ *         description: Error fetching dependency health.
+ */
 router.get('/:username/:reponame/insights/dependencies', fetchDependencyHealth);
 
 module.exports = router;

--- a/server/Routes/RepoRoutes.js
+++ b/server/Routes/RepoRoutes.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
 const { fetchRepoDetails, fetchReadme } = require('../api/githubApi');
-const { Octokit } = require("@octokit/rest");
 const {
     fetchGitTree,
     getRepoTimeline,
@@ -17,23 +16,207 @@ const {
 } = require('../Controllers/GithubController');
 
 const { fetchDependencyHealth } = require('../Controllers/InsightController');
+
 // router.get('/repos/:username/:reponame/file/*', fetchFileContent);
 // router.get('/repos/:username/:reponame/file/*', fetchFileContent);
+
+/**
+ * @swagger
+ * /api/github/repos/{username}/{reponame}/file/{path}:
+ *   get:
+ *     description: Returns the content of a file in the specified repository.
+ *     responses:
+ *       200:
+ *         description: File content retrieved
+ *       500:
+ *         description: Failed to fetch file content.
+ */
 router.get('/repos/:username/:reponame/file/:path', fetchFileContent);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/issues/{issue_number}/timeline:
+ *   get:
+ *     description: Returns the timeline of a specific issue in the repository.
+ *     responses:
+ *       200:
+ *         description: Issue timeline retrieved
+ *       500:
+ *         description: Error fetching issue timeline from GitHub.
+ */
 router.get('/:username/:reponame/issues/:issue_number/timeline', fetchIssueTimeline);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/insights/dependencies:
+ *   get:
+ *     description: Returns dependency health insights for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Dependency health insights retrieved
+ *       500:
+ *         description: Error fetching dependency health.
+ */
 router.get('/:username/:reponame/insights/dependencies', fetchDependencyHealth);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}:
+ *   get:
+ *     description: Returns details of the specified repository.
+ *     responses:
+ *       200:
+ *         description: Repository details retrieved
+ *       500:
+ *         description: Error fetching repository data from GitHub.
+ */
 router.get('/:username/:reponame', fetchRepoDetails);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/readme:
+ *   get:
+ *     description: Returns the README file of the specified repository.
+ *     responses:
+ *       200:
+ *         description: Repository README retrieved
+ *       500:
+ *         description: Error fetching README from GitHub.
+ */
 router.get('/:username/:reponame/readme', fetchReadme);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/commits:
+ *   get:
+ *     description: Returns the commit history for the specified repository.
+ *     responses:
+ *       200:
+ *         description: File commits retrieved
+ *       400:
+ *         description: A file path query parameter is required.
+ *       500:
+ *         description: Error fetching file commit history from GitHub.
+ */
 router.get('/:username/:reponame/commits', fetchFileCommits);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/deployments:
+ *   get:
+ *     description: Returns deployment information for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Deployments retrieved
+ *       500:
+ *         description: Error fetching deployments from GitHub.
+ *       404:
+ *         description: Not Found
+ */
 router.get('/:username/:reponame/deployments', fetchDeployments);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/git/trees/{branch}:
+ *   get:
+ *     description: Returns the git tree for the specified branch in the repository.
+ *     responses:
+ *       200:
+ *         description: Git tree retrieved
+ *       500:
+ *         description: Error fetching Git tree from GitHub.
+ */
 router.get('/:username/:reponame/git/trees/:branch', fetchGitTree);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/contributors:
+ *   get:
+ *     description: Returns the list of contributors for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Contributors retrieved
+ *       500:
+ *         description: Error fetching contributors from GitHub.
+ */
 router.get('/:username/:reponame/contributors', fetchContributors);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/issues:
+ *   get:
+ *     description: Returns the list of issues for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Issues retrieved
+ *       500:
+ *         description: Error fetching issues from GitHub.
+ */
 router.get('/:username/:reponame/issues', fetchIssues);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/pulls:
+ *   get:
+ *     description: Returns the list of pull requests for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Pull requests retrieved
+ *       500:
+ *         description: Error fetching pull requests.
+ */
 router.get('/:username/:reponame/pulls', fetchPullRequests);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/good-first-issues:
+ *   get:
+ *     description: Returns the list of good first issues for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Good first issues retrieved
+ *       500:
+ *         description: Error fetching good first issues from GitHub.
+ */
 router.get('/:username/:reponame/good-first-issues', fetchGoodFirstIssues);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/hotspots:
+ *   get:
+ *     description: Returns code hotspots for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Code hotspots retrieved
+ *       500:
+ *         description: Error fetching code hotspots from GitHub.
+ */
 router.get('/:username/:reponame/hotspots', fetchCodeHotspots);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/timeline:
+ *   get:
+ *     description: Returns the timeline of the specified repository.
+ *     responses:
+ *       200:
+ *         description: Repository timeline retrieved
+ *       500:
+ *         description: Failed to fetch repository timeline data from GitHub.
+ */
 router.get('/:username/:reponame/timeline', getRepoTimeline);
+
+/**
+ * @swagger
+ * /api/github/{username}/{reponame}/insights:
+ *   get:
+ *     description: Returns insights for the specified repository.
+ *     responses:
+ *       200:
+ *         description: Repository insights retrieved
+ *       500:
+ *         description: Error fetching pull request insights from GitHub.
+ */
 router.get('/:username/:reponame/insights', fetchRepoInsights);
 
 module.exports = router;
-

--- a/server/Routes/StatsRoute.js
+++ b/server/Routes/StatsRoute.js
@@ -1,8 +1,17 @@
-
 const router = require('express').Router();
 const { getUserCount } = require('../Controllers/StatsController');
 
-// This endpoint does not require authentication
+/**
+ * @swagger
+ * /api/stats/user-count:
+ *   get:
+ *     description: Returns the total number of users.
+ *     responses:
+ *       200:
+ *         description: User count retrieved
+ *       500:
+ *         description: Error fetching user count.
+ */
 router.get('/user-count', getUserCount);
 
 module.exports = router;

--- a/server/docs/api-docs.yaml
+++ b/server/docs/api-docs.yaml
@@ -1,0 +1,368 @@
+swagger: '2.0'
+info:
+  title: ~GitForMe, Understand any GitHub repository in minutes, not days.
+  description: Automatically generated API documentation  ~GitForMe
+  version: 1.0.0
+basePath: /api
+schemes:
+  - https
+  - http
+paths:
+  /auth/github:
+    get:
+      description: Redirects the user to GitHub for OAuth authentication.
+      responses:
+        '302':
+          description: Redirect to GitHub OAuth
+  /auth/github/callback:
+    get:
+      description: Handles the callback from GitHub after OAuth authentication.
+      parameters:
+        - name: code
+          in: query
+          type: string
+          description: Authorization code returned by GitHub
+      responses:
+        '302':
+          description: Redirect to Home after Login
+        '400':
+          description: No authorization code received.
+        '500':
+          description: Could not retrieve access token.
+  /auth/verifyUser:
+    post:
+      description: Verifies the user token for the frontend.
+      parameters:
+        - in: body
+          name: body
+          description: User token to verify
+          required: true
+          schema:
+            type: object
+      responses:
+        '200':
+          description: User verified
+  /auth/logout:
+    post:
+      description: Clears the user token & logs out the user.
+      responses:
+        '200':
+          description: Logged out Successfully.
+        '500':
+          description: Logout failed.
+  /stats/user-count:
+    get:
+      description: Returns the total number of users.
+      responses:
+        '200':
+          description: User count retrieved
+        '500':
+          description: Error fetching user count.
+  /github/repos/{username}/{reponame}/file/{path}:
+    get:
+      description: Returns the content of a file in the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+        - name: path
+          in: path
+          required: true
+          type: string
+          description: File path in the repository
+      responses:
+        '200':
+          description: File content retrieved
+        '500':
+          description: Failed to fetch file content.
+  /github/{username}/{reponame}/issues/{issue_number}/timeline:
+    get:
+      description: Returns the timeline of a specific issue in the repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+        - name: issue_number
+          in: path
+          required: true
+          type: string
+          description: Issue number
+      responses:
+        '200':
+          description: Issue timeline retrieved
+        '500':
+          description: Error fetching issue timeline from GitHub.
+  /github/{username}/{reponame}/insights/dependencies:
+    get:
+      description: Returns dependency health insights for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Dependency health insights retrieved
+        '500':
+          description: Error fetching dependency health.
+  /github/{username}/{reponame}:
+    get:
+      description: Returns details of the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Repository details retrieved
+        '500':
+          description: Error fetching repository data from GitHub.
+  /github/{username}/{reponame}/readme:
+    get:
+      description: Returns the README file of the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Repository README retrieved
+        '500':
+          description: Error fetching README from GitHub.
+  /github/{username}/{reponame}/commits:
+    get:
+      description: Returns the commit history for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+        - name: path
+          in: query
+          type: string
+          description: File path (optional, for file-specific commits)
+      responses:
+        '200':
+          description: File commits retrieved
+        '400':
+          description: A file path query parameter is required.
+        '500':
+          description: Error fetching file commit history from GitHub.
+  /github/{username}/{reponame}/deployments:
+    get:
+      description: Returns deployment information for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Deployments retrieved
+        '404':
+          description: Not Found
+        '500':
+          description: Error fetching deployments from GitHub.
+  /github/{username}/{reponame}/git/trees/{branch}:
+    get:
+      description: Returns the git tree for the specified branch in the repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+        - name: branch
+          in: path
+          required: true
+          type: string
+          description: Branch name
+      responses:
+        '200':
+          description: Git tree retrieved
+        '500':
+          description: Error fetching Git tree from GitHub.
+  /github/{username}/{reponame}/contributors:
+    get:
+      description: Returns the list of contributors for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Contributors retrieved
+        '500':
+          description: Error fetching contributors from GitHub.
+  /github/{username}/{reponame}/issues:
+    get:
+      description: Returns the list of issues for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Issues retrieved
+        '500':
+          description: Error fetching issues from GitHub.
+  /github/{username}/{reponame}/pulls:
+    get:
+      description: Returns the list of pull requests for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Pull requests retrieved
+        '500':
+          description: Error fetching pull requests.
+  /github/{username}/{reponame}/good-first-issues:
+    get:
+      description: Returns the list of good first issues for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Good first issues retrieved
+        '500':
+          description: Error fetching good first issues from GitHub.
+  /github/{username}/{reponame}/hotspots:
+    get:
+      description: Returns code hotspots for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Code hotspots retrieved
+        '500':
+          description: Error fetching code hotspots from GitHub.
+  /github/{username}/{reponame}/timeline:
+    get:
+      description: Returns the timeline of the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Repository timeline retrieved
+        '500':
+          description: Failed to fetch repository timeline data from GitHub.
+  /github/{username}/{reponame}/insights:
+    get:
+      description: Returns insights for the specified repository.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: GitHub username
+        - name: reponame
+          in: path
+          required: true
+          type: string
+          description: Repository name
+      responses:
+        '200':
+          description: Repository insights retrieved
+        '500':
+          description: Error fetching pull request insights from GitHub.

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1,0 +1,564 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "~GitForMe, Understand any GitHub repository in minutes, not days.",
+    "description": "Automatically generated API documentation  ~GitForMe",
+    "version": "1.0.0"
+  },
+  "basePath": "/api",
+  "schemes": [
+    "https",
+    "http"
+  ],
+  "paths": {
+    "/auth/github": {
+      "get": {
+        "description": "Redirects the user to GitHub for OAuth authentication.",
+        "responses": {
+          "302": {
+            "description": "Redirect to GitHub OAuth"
+          }
+        }
+      }
+    },
+    "/auth/github/callback": {
+      "get": {
+        "description": "Handles the callback from GitHub after OAuth authentication.",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "type": "string",
+            "description": "Authorization code returned by GitHub"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to Home after Login"
+          },
+          "400": {
+            "description": "No authorization code received."
+          },
+          "500": {
+            "description": "Could not retrieve access token."
+          }
+        }
+      }
+    },
+    "/auth/verifyUser": {
+      "post": {
+        "description": "Verifies the user token for the frontend.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "User token to verify",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User verified"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "description": "Clears the user token & logs out the user.",
+        "responses": {
+          "200": {
+            "description": "Logged out Successfully."
+          },
+          "500": {
+            "description": "Logout failed."
+          }
+        }
+      }
+    },
+    "/stats/user-count": {
+      "get": {
+        "description": "Returns the total number of users.",
+        "responses": {
+          "200": {
+            "description": "User count retrieved"
+          },
+          "500": {
+            "description": "Error fetching user count."
+          }
+        }
+      }
+    },
+    "/github/repos/{username}/{reponame}/file/{path}": {
+      "get": {
+        "description": "Returns the content of a file in the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "File path in the repository"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content retrieved"
+          },
+          "500": {
+            "description": "Failed to fetch file content."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/issues/{issue_number}/timeline": {
+      "get": {
+        "description": "Returns the timeline of a specific issue in the repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          },
+          {
+            "name": "issue_number",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Issue number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Issue timeline retrieved"
+          },
+          "500": {
+            "description": "Error fetching issue timeline from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/insights/dependencies": {
+      "get": {
+        "description": "Returns dependency health insights for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dependency health insights retrieved"
+          },
+          "500": {
+            "description": "Error fetching dependency health."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}": {
+      "get": {
+        "description": "Returns details of the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository details retrieved"
+          },
+          "500": {
+            "description": "Error fetching repository data from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/readme": {
+      "get": {
+        "description": "Returns the README file of the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository README retrieved"
+          },
+          "500": {
+            "description": "Error fetching README from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/commits": {
+      "get": {
+        "description": "Returns the commit history for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "type": "string",
+            "description": "File path (optional, for file-specific commits)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File commits retrieved"
+          },
+          "400": {
+            "description": "A file path query parameter is required."
+          },
+          "500": {
+            "description": "Error fetching file commit history from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/deployments": {
+      "get": {
+        "description": "Returns deployment information for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployments retrieved"
+          },
+          "500": {
+            "description": "Error fetching deployments from GitHub."
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/git/trees/{branch}": {
+      "get": {
+        "description": "Returns the git tree for the specified branch in the repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          },
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Branch name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Git tree retrieved"
+          },
+          "500": {
+            "description": "Error fetching Git tree from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/contributors": {
+      "get": {
+        "description": "Returns the list of contributors for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contributors retrieved"
+          },
+          "500": {
+            "description": "Error fetching contributors from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/issues": {
+      "get": {
+        "description": "Returns the list of issues for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Issues retrieved"
+          },
+          "500": {
+            "description": "Error fetching issues from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/pulls": {
+      "get": {
+        "description": "Returns the list of pull requests for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pull requests retrieved"
+          },
+          "500": {
+            "description": "Error fetching pull requests."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/good-first-issues": {
+      "get": {
+        "description": "Returns the list of good first issues for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Good first issues retrieved"
+          },
+          "500": {
+            "description": "Error fetching good first issues from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/hotspots": {
+      "get": {
+        "description": "Returns code hotspots for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Code hotspots retrieved"
+          },
+          "500": {
+            "description": "Error fetching code hotspots from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/timeline": {
+      "get": {
+        "description": "Returns the timeline of the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository timeline retrieved"
+          },
+          "500": {
+            "description": "Failed to fetch repository timeline data from GitHub."
+          }
+        }
+      }
+    },
+    "/github/{username}/{reponame}/insights": {
+      "get": {
+        "description": "Returns insights for the specified repository.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "GitHub username"
+          },
+          {
+            "name": "reponame",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Repository name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository insights retrieved"
+          },
+          "500": {
+            "description": "Error fetching pull request insights from GitHub."
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,9 @@ const insightsRoutes = require('./Routes/InsightRoutes');
 //added the route here
 const statsRoute = require('./Routes/StatsRoute');
 const { requireAuth } = require("./Middlewares/AuthMiddleware");
+const swaggerUi = require("swagger-ui-express");
+const swaggerDocument = require("./docs/swagger.json");
+
 const PORT = process.env.PORT || 3000;
 const app = express();
 app.set('trust proxy', 1); 
@@ -88,13 +91,8 @@ app.use("/api/github", requireAuth);
 app.use("/api/github", insightsRoutes);
 app.use("/api/github", repoRoute);     
 
-app.post('/api/auth/logout', (req, res) => {
-  req.session.destroy((err) => {
-    if (err) return res.status(500).json({ message: 'Logout failed' });
-    res.clearCookie('token'); 
-    res.json({ status: true });
-  });
-});
+// Serve Swagger UI Docs...
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use((req, res) => res.status(404).json({ error: "Route not found" }));
 // const PORT = process.env.PORT || 3000;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^17.1.0",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
+        "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.2",
         "redis": "^4.7.1",
@@ -342,6 +343,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1305,6 +1312,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "dotenv": "^17.1.0",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
+    "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.2",
     "redis": "^4.7.1",
@@ -20,6 +21,8 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "echo \"No tests specified\" && exit 0",
+    "docs:swagger": "node scripts/swaggerGen.js",
+    "docs:yaml": "node scripts/export-yaml.js"
   }
 }

--- a/server/scripts/export-yaml.js
+++ b/server/scripts/export-yaml.js
@@ -1,0 +1,12 @@
+// scripts/export-yaml.js
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const swaggerSpec = require('../docs/swagger.json');
+
+const outDir = path.join(__dirname, '..', 'docs');
+const outFile = path.join(outDir, 'api-docs.yaml');
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(outFile, yaml.dump(swaggerSpec, { noRefs: true }));
+console.log('✅ Swagger YAML exported to docs/api-docs.yaml');

--- a/server/scripts/swaggerGen.js
+++ b/server/scripts/swaggerGen.js
@@ -1,0 +1,20 @@
+// swaggerGen.js
+const swaggerAutogen = require("swagger-autogen")();
+
+
+const doc = {
+    info: {
+        title: "~GitForMe, Understand any GitHub repository in minutes, not days.",
+        description: "Automatically generated API documentation  ~GitForMe",
+        version: "1.0.0",
+    },
+    schemes: ["https", "http"],
+    basePath: "/api",
+}
+
+const outputFile = "../docs/swagger.json"           // The output file
+const routes = ["../Routes/*.js"]         // Add your route files
+
+swaggerAutogen(outputFile, routes, doc).then(() => {
+    console.log("Swagger documentation generated successfully!")
+})


### PR DESCRIPTION
📄 Description

This PR introduces automated Swagger documentation generation for the API. Previously, our routes lacked API documentation, making it harder to understand and explore endpoints. With this implementation, Swagger JSON and YAML files are generated and served, providing a clear interface for API consumers.

Changes made:
- Added swagger-autogen script (scripts/swaggerGen.js) to auto-generate Swagger documentation.
- Integrated JSON → YAML conversion script for compatibility (scripts/export-yaml.js).
- Generated swagger.json and api-docs.yaml under docs/ directory.
- Configured Express to serve Swagger UI at /api-docs.
- Verified Swagger docs rendering locally.

🔗 Related Issues
Closes #28 

📸 Visual Changes (if applicable)
<img width="1905" height="943" alt="gitforme" src="https://github.com/user-attachments/assets/b2808644-0a95-4e49-aa4e-448f875b96e3" />
